### PR TITLE
custom_url parameter to have custom urls

### DIFF
--- a/lambda_functions/create_shorturl/lambda_function.py
+++ b/lambda_functions/create_shorturl/lambda_function.py
@@ -6,15 +6,22 @@ def generate_token(value, length = 6):
     chars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890"
     random.seed(value)
     return ''.join(random.choice(chars) for _ in range(length))
+
 def lambda_handler(event, context):
     if 'url' not in event['body']:
         return {'statusCode': 400,'body': json.dumps({'error': "No 'url' provided has been provided."})}
-
     url = json.loads(event['body'])['url']
-    token = generate_token(url)
+
+    if 'custom_url' not in event['body']:
+        token = generate_token(url)
+    else:
+        custom_url = json.loads(event['body'])['custom_url']
+        if custom_url == "":
+            token = generate_token(url)
+        else:
+            token = custom_url
 
     s3 = boto3.client('s3')
     s3.put_object(ACL='public-read',Bucket=os.getenv('BUCKET_NAME'), Key=token, WebsiteRedirectLocation=url)
 
     return {'statusCode': 200,'body': json.dumps({'short_url' : 'https://' + os.getenv('BUCKET_NAME') + '/' + token, 'url': url, 'token': token})}
-


### PR DESCRIPTION
The *custom_url* parameter -- if specified -- gets used as the new "short" url. Sometimes you don't want the url to be short and sweet, but you want it to be descriptive and sweet.